### PR TITLE
Add colorgrid function

### DIFF
--- a/random/cli_colors
+++ b/random/cli_colors
@@ -1,0 +1,34 @@
+# Source: @plasmarob https://unix.stackexchange.com/a/285956
+
+function colorgrid( )
+{
+    iter=16
+    while [ $iter -lt 52 ]
+    do
+        second=$[$iter+36]
+        third=$[$second+36]
+        four=$[$third+36]
+        five=$[$four+36]
+        six=$[$five+36]
+        seven=$[$six+36]
+        if [ $seven -gt 250 ];then seven=$[$seven-251]; fi
+
+        echo -en "\033[38;5;$(echo $iter)m█ "
+        printf "%03d" $iter
+        echo -en "   \033[38;5;$(echo $second)m█ "
+        printf "%03d" $second
+        echo -en "   \033[38;5;$(echo $third)m█ "
+        printf "%03d" $third
+        echo -en "   \033[38;5;$(echo $four)m█ "
+        printf "%03d" $four
+        echo -en "   \033[38;5;$(echo $five)m█ "
+        printf "%03d" $five
+        echo -en "   \033[38;5;$(echo $six)m█ "
+        printf "%03d" $six
+        echo -en "   \033[38;5;$(echo $seven)m█ "
+        printf "%03d" $seven
+
+        iter=$[$iter+1]
+        printf '\r\n'
+    done
+}


### PR DESCRIPTION
Prints all the colors in the command line interface to see what the different colors look like with a given background color or other color related things.

The code was authored by @plasmarob and shared on https://unix.stackexchange.com/a/285956/379979.

I found it really handy when trying out different color combination in CLI tools.